### PR TITLE
Refine DAG docstrings and use TaskFlow explicitly

### DIFF
--- a/dags/listen_to_the_stream.py
+++ b/dags/listen_to_the_stream.py
@@ -1,10 +1,10 @@
 """
-### DAG continuously listening to a Kafka topic for a specific message
+### Continuously Listen to a Kafka Topic for a Specific Message
 
-This DAG will always run and asynchronously monitor a Kafka topic for a message 
+This DAG will always run and asynchronously monitor a Kafka topic for a message
 which causes the funtion supplied to the `apply_function` parameter to return a value.
-If a value is returned by the `apply_function`, the `event_triggered_function` is 
-executed. Afterwards the task will go into a deferred state again. 
+If a value is returned by the `apply_function`, the `event_triggered_function` is
+executed. Afterwards the task will go into a deferred state again.
 """
 
 from airflow.decorators import dag
@@ -65,7 +65,7 @@ def event_triggered_function(message, **context):
     render_template_as_native_obj=True,
 )
 def listen_to_the_stream():
-    listen_for_mood = AwaitMessageTriggerFunctionSensor(
+    AwaitMessageTriggerFunctionSensor(
         task_id="listen_for_mood",
         kafka_config_id="kafka_listener",
         topics=[KAFKA_TOPIC],

--- a/dags/produce_consume_treats.py
+++ b/dags/produce_consume_treats.py
@@ -1,5 +1,5 @@
 """
-### DAG which produces to and consumes from a Kafka cluster
+### Produce to and Consume from a Kafka Cluster
 
 This DAG will produce messages of several elements to a Kafka cluster and consume
 them.
@@ -86,10 +86,8 @@ def produce_consume_treats():
         kafka_config_id="kafka_default",
         topic=KAFKA_TOPIC,
         producer_function=prod_function,
-        producer_function_args=["{{ ti.xcom_pull(task_ids='get_number_of_treats')}}"],
-        producer_function_kwargs={
-            "pet_name": "{{ ti.xcom_pull(task_ids='get_your_pet_name')}}"
-        },
+        producer_function_args=[get_number_of_treats(NUMBER_OF_TREATS)],
+        producer_function_kwargs={"pet_name": get_your_pet_name(YOUR_PET_NAME)},
         poll_timeout=10,
     )
 
@@ -98,18 +96,10 @@ def produce_consume_treats():
         kafka_config_id="kafka_default",
         topics=[KAFKA_TOPIC],
         apply_function=consume_function,
-        apply_function_kwargs={
-            "name": "{{ ti.xcom_pull(task_ids='get_pet_owner_name')}}"
-        },
+        apply_function_kwargs={"name": get_pet_owner_name(YOUR_NAME)},
         poll_timeout=20,
         max_messages=1000,
     )
-
-    [
-        get_your_pet_name(YOUR_PET_NAME),
-        get_number_of_treats(NUMBER_OF_TREATS),
-    ] >> produce_treats
-    get_pet_owner_name(YOUR_NAME) >> consume_treats
 
     produce_treats >> consume_treats
 

--- a/dags/walking_your_pet.py
+++ b/dags/walking_your_pet.py
@@ -1,7 +1,7 @@
 """
-### Simple DAG that runs one task with params
+### Run a Simple DAG with Params
 
-This DAG uses one string type param and uses it in a python decorated task.
+This DAG uses one string type param and uses it in a TaskFlow task.
 """
 
 from airflow.decorators import dag, task


### PR DESCRIPTION
Proposing small updates to the DAG docstrings, mainly:
- Trying not to use "DAG" in the heading
- Use action language in what becomes the DAG's title on the Registry
- Casing updates for titling

Also, instead of using a Jinja template to reference XComs from TaskFlow tasks, proposing to calling the task explicitly in the consuming traditional operator task. (This is a nice-to-have really so feel free to nix.)